### PR TITLE
[feature/#6] Add APIs for managing study groups

### DIFF
--- a/src/main/java/com/api/meetudy/global/config/SecurityConfig.java
+++ b/src/main/java/com/api/meetudy/global/config/SecurityConfig.java
@@ -90,6 +90,7 @@ public class SecurityConfig {
                                 , "/v2/swagger-config"
                                 , "/swagger-resources/**").permitAll()
                         .requestMatchers("/oauth2/callback/kakao").permitAll()
+                        .requestMatchers("/study-groups/**").hasRole("USER")
                 );
 
         httpSecurity

--- a/src/main/java/com/api/meetudy/global/response/status/ErrorStatus.java
+++ b/src/main/java/com/api/meetudy/global/response/status/ErrorStatus.java
@@ -18,9 +18,15 @@ public enum ErrorStatus {
     REFRESH_TOKEN_LOGGED_OUT(HttpStatus.UNAUTHORIZED, "AUTH406", "The refresh token has already been logged out."),
 
     // Member
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER400", "The user is not found."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER400", "Member not found."),
     USERNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER401", "The username already exists."),
     PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "MEMBER402", "The password does not match."),
+
+    // Study Group
+    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP400", "Group not found."),
+    GROUP_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP401", "Group member not found."),
+    MAX_PARTICIPANTS_EXCEEDED(HttpStatus.BAD_REQUEST, "GROUP402", "Study group has already reached the maximum number of participants."),
+    REQUEST_ALREADY_SENT(HttpStatus.BAD_REQUEST, "GROUP403", "Your participation request for this study group has already been sent."),
     ;
 
 

--- a/src/main/java/com/api/meetudy/global/util/EnumValidator.java
+++ b/src/main/java/com/api/meetudy/global/util/EnumValidator.java
@@ -1,0 +1,13 @@
+package com.api.meetudy.global.util;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, Enum> {
+
+    @Override
+    public boolean isValid(Enum value, ConstraintValidatorContext context) {
+        return value != null;
+    }
+
+}

--- a/src/main/java/com/api/meetudy/global/util/ValidEnum.java
+++ b/src/main/java/com/api/meetudy/global/util/ValidEnum.java
@@ -1,0 +1,24 @@
+package com.api.meetudy.global.util;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = EnumValidator.class)
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEnum {
+
+    String message() default "Invalid enum value";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    Class<? extends Enum<?>> target();
+
+}

--- a/src/main/java/com/api/meetudy/member/controller/MemberController.java
+++ b/src/main/java/com/api/meetudy/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.api.meetudy.global.response.ApiResponse;
 import com.api.meetudy.member.dto.SignInDto;
 import com.api.meetudy.member.dto.SignUpDto;
 import com.api.meetudy.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,39 +22,44 @@ public class MemberController {
     public static final String REFRESH_TOKEN_PARAM = "refreshToken";
     public static final String BEARER_PREFIX = "Bearer ";
 
-    @PostMapping("/signup")
+    @Operation(summary = "회원가입 API")
+    @PostMapping("/sign-up")
     public ResponseEntity<ApiResponse<String>> signUp(@Valid @RequestBody SignUpDto signUpDto) {
-        String message = memberService.signUp(signUpDto);
-        return ResponseEntity.ok(ApiResponse.onSuccess(message));
+        String response = memberService.signUp(signUpDto);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
-    @PostMapping("/signin")
+    @Operation(summary = "로그인 API")
+    @PostMapping("/sign-in")
     public ResponseEntity<ApiResponse<JwtTokenDto>> signIn(@Valid @RequestBody SignInDto signInDto) {
-        JwtTokenDto jwtTokenDto = memberService.signIn(signInDto);
-        return ResponseEntity.ok(ApiResponse.onSuccess(jwtTokenDto));
+        JwtTokenDto response = memberService.signIn(signInDto);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
+    @Operation(summary = "카카오 로그인 API")
     @PostMapping("/kakao/login")
     public ResponseEntity<ApiResponse<JwtTokenDto>> kakaoLogin(@RequestParam String code) {
-        JwtTokenDto jwtTokenDto = memberService.signInWithKakao(code);
-        return ResponseEntity.ok(ApiResponse.onSuccess(jwtTokenDto));
+        JwtTokenDto response = memberService.signInWithKakao(code);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
+    @Operation(summary = "로그아웃 API")
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<String>> logout(@RequestHeader(AUTHORIZATION_HEADER) String accessToken) {
         String token = accessToken.replace(BEARER_PREFIX, "");
-        String message = memberService.logout(token);
+        String response = memberService.logout(token);
 
-        return ResponseEntity.ok(ApiResponse.onSuccess(message));
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
+    @Operation(summary = "토큰 갱신 API")
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<JwtTokenDto>> refreshToken(@RequestHeader(AUTHORIZATION_HEADER) String accessToken,
                                                                  @RequestParam(REFRESH_TOKEN_PARAM) String refreshToken) {
         String token = accessToken.replace(BEARER_PREFIX, "");
-        JwtTokenDto jwtTokenDto = memberService.refreshToken(token, refreshToken);
+        JwtTokenDto response = memberService.refreshToken(token, refreshToken);
 
-        return ResponseEntity.ok(ApiResponse.onSuccess(jwtTokenDto));
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
 }

--- a/src/main/java/com/api/meetudy/member/entity/Member.java
+++ b/src/main/java/com/api/meetudy/member/entity/Member.java
@@ -38,7 +38,17 @@ public class Member implements UserDetails {
     private String nickname;
 
     @Column(nullable = true)
+    private String major;
+
+    @Column(nullable = true)
+    private String introduction;
+
+    @Column(nullable = true)
     private String profileImage;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer activityScore = 50;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -58,6 +68,14 @@ public class Member implements UserDetails {
 
     public void updateRoles(List<String> roles) {
         this.roles = roles;
+    }
+
+    public void updateActivityScore(Integer activityScore) {
+        this.activityScore = activityScore;
+    }
+
+    public void updateUsername(String username) {
+        this.username = username;
     }
 
     @Override

--- a/src/main/java/com/api/meetudy/member/service/MemberService.java
+++ b/src/main/java/com/api/meetudy/member/service/MemberService.java
@@ -23,6 +23,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.Principal;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
@@ -79,6 +80,7 @@ public class MemberService {
         ResponseEntity<String> userInfo = kakaoLoginService.requestUserInfo(kakaoToken);
 
         Member member = kakaoLoginService.getUserInfo(userInfo);
+        member.updateUsername(member.getEmail());
         Member existMember = memberRepository.findByEmail(member.getEmail()).orElse(null);
 
         if(existMember == null) {
@@ -123,6 +125,12 @@ public class MemberService {
         tokenService.storeRefreshToken(authentication.getName(), jwtToken);
 
         return jwtToken;
+    }
+
+    public Member getCurrentMember(Principal principal) {
+        String username = principal.getName();
+        return memberRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
     }
 
     private Authentication authenticate(UsernamePasswordAuthenticationToken authenticationToken) {

--- a/src/main/java/com/api/meetudy/study/group/controller/StudyGroupController.java
+++ b/src/main/java/com/api/meetudy/study/group/controller/StudyGroupController.java
@@ -1,0 +1,81 @@
+package com.api.meetudy.study.group.controller;
+
+import com.api.meetudy.global.response.ApiResponse;
+import com.api.meetudy.member.service.MemberService;
+import com.api.meetudy.study.group.dto.StudyGroupApplicantDto;
+import com.api.meetudy.study.group.dto.StudyGroupDto;
+import com.api.meetudy.study.group.service.GroupJoinService;
+import com.api.meetudy.study.group.service.GroupManagementService;
+import com.api.meetudy.study.group.service.GroupRetrievalService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/study-groups")
+public class StudyGroupController {
+
+    private final MemberService memberService;
+    private final GroupJoinService groupJoinService;
+    private final GroupManagementService groupManagementService;
+    private final GroupRetrievalService groupRetrievalService;
+
+    @Operation(summary = "스터디 그룹 가입 요청 API")
+    @PostMapping("/{groupId}")
+    public ResponseEntity<ApiResponse<String>> requestJoinGroup(@PathVariable Long groupId,
+                                                                Principal principal) {
+        String message = groupJoinService.requestJoinGroup(groupId, memberService.getCurrentMember(principal));
+        return ResponseEntity.ok(ApiResponse.onSuccess(message));
+    }
+
+    @Operation(summary = "스터디 그룹 생성 API")
+    @PostMapping
+    public ResponseEntity<ApiResponse<String>> createStudyGroup(@Valid @RequestBody StudyGroupDto studyGroupDto,
+                                                                Principal principal) {
+        String response = groupManagementService.createStudyGroup(studyGroupDto, memberService.getCurrentMember(principal));
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "스터디 그룹 가입 요청 승인 API")
+    @PutMapping("/{groupMemberId}/approval")
+    public ResponseEntity<ApiResponse<String>> approveJoinRequest(@PathVariable Long groupMemberId) {
+        String response = groupManagementService.approveJoinRequest(groupMemberId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "스터디 그룹 가입 요청 거절 API")
+    @PutMapping("/{groupMemberId}/rejection")
+    public ResponseEntity<ApiResponse<String>> rejectJoinRequest(@PathVariable Long groupMemberId) {
+        String response = groupManagementService.rejectJoinRequest(groupMemberId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "스터디 그룹에 대한 가입 요청 조회 API")
+    @GetMapping("/{groupId}")
+    public ResponseEntity<ApiResponse<List<StudyGroupApplicantDto>>> getJoinRequests(@PathVariable Long groupId) {
+        List<StudyGroupApplicantDto> response = groupJoinService.getJoinRequests(groupId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "사용자가 리더로 있는 스터디 그룹 조회 API")
+    @GetMapping("/created-groups")
+    public ResponseEntity<ApiResponse<List<StudyGroupDto>>> getCreatedStudyGroups(Principal principal) {
+        List<StudyGroupDto> response = groupRetrievalService.getCreatedStudyGroups(memberService.getCurrentMember(principal));
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "사용자가 멤버로 있는 스터디 그룹 조회 API")
+    @GetMapping("/joined-groups")
+    public ResponseEntity<ApiResponse<List<StudyGroupDto>>> getJoinedStudyGroups(Principal principal) {
+        List<StudyGroupDto> response = groupRetrievalService.getJoinedStudyGroups(memberService.getCurrentMember(principal)
+        );
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+}

--- a/src/main/java/com/api/meetudy/study/group/dto/StudyGroupApplicantDto.java
+++ b/src/main/java/com/api/meetudy/study/group/dto/StudyGroupApplicantDto.java
@@ -1,0 +1,18 @@
+package com.api.meetudy.study.group.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StudyGroupApplicantDto {
+
+    private String nickname;
+
+    private String major;
+
+    private String introduction;
+
+    private Integer activityScore;
+
+}

--- a/src/main/java/com/api/meetudy/study/group/dto/StudyGroupDto.java
+++ b/src/main/java/com/api/meetudy/study/group/dto/StudyGroupDto.java
@@ -1,0 +1,55 @@
+package com.api.meetudy.study.group.dto;
+
+import com.api.meetudy.global.util.ValidEnum;
+import com.api.meetudy.study.group.enums.Location;
+import com.api.meetudy.study.group.enums.StudyCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StudyGroupDto {
+
+    @Schema(description = "The unique identifier of the study group.",
+            example = "1")
+    private Long id;
+
+    @ValidEnum(target = StudyCategory.class)
+    @Schema(description = "The category or type of the study group.",
+            example = "LANGUAGE, CERTIFICATION")
+    private StudyCategory category;
+
+    @NotBlank
+    @Schema(description = "The name of the study group.")
+    private String name;
+
+    @NotBlank
+    @Schema(description = "Description of the study group.")
+    private String description;
+
+    @NotBlank
+    @Schema(description = "The duration of the study.")
+    private String duration;
+
+    @NotNull
+    @Schema(description = "Indicates whether the study is conducted online or offline.")
+    private Boolean isOnline;
+
+    @ValidEnum(target = Location.class)
+    @Schema(description = "Location of the study.")
+    private Location location;
+
+    @NotNull
+    @Positive
+    @Schema(description = "Maximum number of participants.")
+    private Integer maxParticipants;
+
+    @NotBlank
+    @Schema(description = "The method or approach used for conducting the study.")
+    private String method;
+
+}

--- a/src/main/java/com/api/meetudy/study/group/entity/StudyGroup.java
+++ b/src/main/java/com/api/meetudy/study/group/entity/StudyGroup.java
@@ -1,0 +1,58 @@
+package com.api.meetudy.study.group.entity;
+
+import com.api.meetudy.member.entity.Member;
+import com.api.meetudy.study.group.enums.Location;
+import com.api.meetudy.study.group.enums.StudyCategory;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@Entity
+@ToString
+@Table(name  = "study_group")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private String duration;
+
+    @Column(nullable = false)
+    private Integer maxParticipants;
+
+    @Column(nullable = false)
+    private Boolean isOnline;
+
+    @Column(nullable = false)
+    private String method;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private StudyCategory category;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Location location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leader_id", nullable = false)
+    private Member leader;
+
+    @OneToMany(mappedBy = "studyGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<StudyGroupMember> members = new ArrayList<>();
+
+}

--- a/src/main/java/com/api/meetudy/study/group/entity/StudyGroupMember.java
+++ b/src/main/java/com/api/meetudy/study/group/entity/StudyGroupMember.java
@@ -1,0 +1,38 @@
+package com.api.meetudy.study.group.entity;
+
+import com.api.meetudy.member.entity.Member;
+import com.api.meetudy.study.group.enums.GroupMemberStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@Entity
+@ToString
+@Table(name  = "study_group_member")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroupMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private GroupMemberStatus status = GroupMemberStatus.PENDING;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_group_id", nullable = false)
+    private StudyGroup studyGroup;
+
+    public void updateStatus(GroupMemberStatus status) {
+        this.status = status;
+    }
+
+}

--- a/src/main/java/com/api/meetudy/study/group/enums/GroupMemberStatus.java
+++ b/src/main/java/com/api/meetudy/study/group/enums/GroupMemberStatus.java
@@ -1,0 +1,11 @@
+package com.api.meetudy.study.group.enums;
+
+public enum GroupMemberStatus {
+
+    // 요청 대기
+    PENDING,
+
+    // 가입 승인
+    ACCEPTED
+
+}

--- a/src/main/java/com/api/meetudy/study/group/enums/Location.java
+++ b/src/main/java/com/api/meetudy/study/group/enums/Location.java
@@ -1,0 +1,37 @@
+package com.api.meetudy.study.group.enums;
+
+public enum Location {
+
+    SEOUL,
+
+    GYEONGGIDO,
+
+    GANGWONDO,
+
+    CHUNGCHEONGNAMDO,
+
+    CHUNGCHEONGBUKDO,
+
+    JEOLLANAMDO,
+
+    JEOLLABUKDO,
+
+    GYEONGSANGNAMDO,
+
+    GYEONGSANGBUKDO,
+
+    JEJU,
+
+    INCHEON,
+
+    DAEJEON,
+
+    DAEGU,
+
+    GWANGJU,
+
+    ULSAN,
+
+    BUSAN
+
+}

--- a/src/main/java/com/api/meetudy/study/group/enums/StudyCategory.java
+++ b/src/main/java/com/api/meetudy/study/group/enums/StudyCategory.java
@@ -1,0 +1,26 @@
+package com.api.meetudy.study.group.enums;
+
+public enum StudyCategory {
+
+    // 어학
+    LANGUAGE,
+
+    // 자격증
+    CERTIFICATION,
+
+    // 프로그래밍
+    PROGRAMMING,
+
+    // 취업/커리어
+    CAREER,
+
+    // 고시/공무원
+    QUALIFICATION_EXAM,
+
+    // 취미
+    HOBBY,
+
+    // 기타
+    OTHER
+
+}

--- a/src/main/java/com/api/meetudy/study/group/mapper/StudyGroupMapper.java
+++ b/src/main/java/com/api/meetudy/study/group/mapper/StudyGroupMapper.java
@@ -1,0 +1,47 @@
+package com.api.meetudy.study.group.mapper;
+
+import com.api.meetudy.member.entity.Member;
+import com.api.meetudy.study.group.dto.StudyGroupApplicantDto;
+import com.api.meetudy.study.group.dto.StudyGroupDto;
+import com.api.meetudy.study.group.entity.StudyGroup;
+import com.api.meetudy.study.group.entity.StudyGroupMember;
+import org.mapstruct.IterableMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Mapper(componentModel = "spring")
+public interface StudyGroupMapper {
+
+    @Mapping(target = "id", ignore = true)
+    StudyGroupMember toStudyGroupMember(StudyGroup studyGroup, Member member);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "leader", source = "leader")
+    @Mapping(target = "members", ignore = true)
+    StudyGroup toStudyGroup(StudyGroupDto dto, Member leader);
+
+    @Mapping(source = "member.nickname", target = "nickname")
+    @Mapping(source = "member.major", target = "major")
+    @Mapping(source = "member.introduction", target = "introduction")
+    @Mapping(source = "member.activityScore", target = "activityScore")
+    StudyGroupApplicantDto toStudyGroupApplicantDto(StudyGroupMember studyGroupMember);
+
+    StudyGroupDto toStudyGroupDto(StudyGroup studyGroup);
+
+    @IterableMapping(elementTargetType = StudyGroupApplicantDto.class)
+    List<StudyGroupApplicantDto> toStudyGroupApplicantDtoList(List<StudyGroupMember> studyGroupMembers);
+
+    @IterableMapping(elementTargetType = StudyGroupDto.class)
+    List<StudyGroupDto> toStudyGroupDtoList(List<StudyGroup> studyGroups);
+
+    default List<StudyGroupDto> toStudyGroupDtoListFromMembers(List<StudyGroupMember> studyGroupMembers) {
+        return studyGroupMembers.stream()
+                .map(StudyGroupMember::getStudyGroup)
+                .map(this::toStudyGroupDto)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/api/meetudy/study/group/repository/StudyGroupMemberRepository.java
+++ b/src/main/java/com/api/meetudy/study/group/repository/StudyGroupMemberRepository.java
@@ -1,0 +1,21 @@
+package com.api.meetudy.study.group.repository;
+
+import com.api.meetudy.member.entity.Member;
+import com.api.meetudy.study.group.entity.StudyGroup;
+import com.api.meetudy.study.group.entity.StudyGroupMember;
+import com.api.meetudy.study.group.enums.GroupMemberStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface StudyGroupMemberRepository extends JpaRepository<StudyGroupMember, Long> {
+
+    List<StudyGroupMember> findByStudyGroupAndStatus(StudyGroup studyGroup, GroupMemberStatus groupMemberStatus);
+
+    List<StudyGroupMember> findByMember(Member member);
+
+    boolean existsByStudyGroupAndMember(StudyGroup studyGroup, Member member);
+
+}

--- a/src/main/java/com/api/meetudy/study/group/repository/StudyGroupRepository.java
+++ b/src/main/java/com/api/meetudy/study/group/repository/StudyGroupRepository.java
@@ -1,0 +1,15 @@
+package com.api.meetudy.study.group.repository;
+
+import com.api.meetudy.member.entity.Member;
+import com.api.meetudy.study.group.entity.StudyGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
+
+    List<StudyGroup> findByLeader(Member member);
+
+}

--- a/src/main/java/com/api/meetudy/study/group/service/GroupJoinService.java
+++ b/src/main/java/com/api/meetudy/study/group/service/GroupJoinService.java
@@ -1,0 +1,53 @@
+package com.api.meetudy.study.group.service;
+
+import com.api.meetudy.global.response.exception.CustomException;
+import com.api.meetudy.global.response.status.ErrorStatus;
+import com.api.meetudy.member.entity.Member;
+import com.api.meetudy.study.group.dto.StudyGroupApplicantDto;
+import com.api.meetudy.study.group.entity.StudyGroup;
+import com.api.meetudy.study.group.entity.StudyGroupMember;
+import com.api.meetudy.study.group.enums.GroupMemberStatus;
+import com.api.meetudy.study.group.mapper.StudyGroupMapper;
+import com.api.meetudy.study.group.repository.StudyGroupMemberRepository;
+import com.api.meetudy.study.group.repository.StudyGroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GroupJoinService {
+
+    private final StudyGroupRepository groupRepository;
+    private final StudyGroupMemberRepository groupMemberRepository;
+    private final StudyGroupMapper studyGroupMapper;
+
+    @Transactional
+    public String requestJoinGroup(Long groupId, Member member) {
+        StudyGroup studyGroup = groupRepository.findById(groupId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.GROUP_NOT_FOUND));
+
+        boolean isAlreadyRequested = groupMemberRepository.existsByStudyGroupAndMember(studyGroup, member);
+        if (isAlreadyRequested) {
+            throw new CustomException(ErrorStatus.REQUEST_ALREADY_SENT);
+        }
+
+        StudyGroupMember studyGroupMember = studyGroupMapper.toStudyGroupMember(studyGroup, member);
+        groupMemberRepository.save(studyGroupMember);
+
+        return "Join request submitted successfully";
+    }
+
+    @Transactional(readOnly = true)
+    public List<StudyGroupApplicantDto> getJoinRequests(Long groupId) {
+        StudyGroup studyGroup = groupRepository.findById(groupId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.GROUP_NOT_FOUND));
+
+        List<StudyGroupMember> pendingMembers = groupMemberRepository.findByStudyGroupAndStatus(studyGroup, GroupMemberStatus.PENDING);
+
+        return studyGroupMapper.toStudyGroupApplicantDtoList(pendingMembers);
+    }
+
+}

--- a/src/main/java/com/api/meetudy/study/group/service/GroupManagementService.java
+++ b/src/main/java/com/api/meetudy/study/group/service/GroupManagementService.java
@@ -1,0 +1,64 @@
+package com.api.meetudy.study.group.service;
+
+import com.api.meetudy.global.response.exception.CustomException;
+import com.api.meetudy.global.response.status.ErrorStatus;
+import com.api.meetudy.member.entity.Member;
+import com.api.meetudy.study.group.dto.StudyGroupDto;
+import com.api.meetudy.study.group.entity.StudyGroup;
+import com.api.meetudy.study.group.entity.StudyGroupMember;
+import com.api.meetudy.study.group.enums.GroupMemberStatus;
+import com.api.meetudy.study.group.mapper.StudyGroupMapper;
+import com.api.meetudy.study.group.repository.StudyGroupMemberRepository;
+import com.api.meetudy.study.group.repository.StudyGroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GroupManagementService {
+
+    private final StudyGroupRepository groupRepository;
+    private final StudyGroupMemberRepository groupMemberRepository;
+    private final StudyGroupMapper studyGroupMapper;
+
+    @Transactional
+    public String createStudyGroup(StudyGroupDto studyGroupDto, Member member) {
+        StudyGroup studyGroup = studyGroupMapper.toStudyGroup(studyGroupDto, member);
+
+        member.updateActivityScore(member.getActivityScore() + 8);
+        groupRepository.save(studyGroup);
+
+        return "Study group has been successfully created.";
+    }
+
+    @Transactional
+    public String approveJoinRequest(Long groupMemberId) {
+        StudyGroupMember groupMember = groupMemberRepository.findById(groupMemberId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.GROUP_MEMBER_NOT_FOUND));
+
+        StudyGroup studyGroup = groupMember.getStudyGroup();
+
+        if (studyGroup.getMembers().size() >= studyGroup.getMaxParticipants()) {
+            throw new CustomException(ErrorStatus.MAX_PARTICIPANTS_EXCEEDED);
+        }
+
+        groupMember.updateStatus(GroupMemberStatus.ACCEPTED);
+
+        Member member = groupMember.getMember();
+        member.updateActivityScore(member.getActivityScore() + 5);
+
+        return "The join request has been approved.";
+    }
+
+    @Transactional
+    public String rejectJoinRequest(Long groupMemberId) {
+        StudyGroupMember groupMember = groupMemberRepository.findById(groupMemberId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.GROUP_MEMBER_NOT_FOUND));
+
+        groupMemberRepository.delete(groupMember);
+
+        return "The join request has been rejected.";
+    }
+
+}

--- a/src/main/java/com/api/meetudy/study/group/service/GroupRetrievalService.java
+++ b/src/main/java/com/api/meetudy/study/group/service/GroupRetrievalService.java
@@ -1,0 +1,36 @@
+package com.api.meetudy.study.group.service;
+
+import com.api.meetudy.member.entity.Member;
+import com.api.meetudy.study.group.dto.StudyGroupDto;
+import com.api.meetudy.study.group.entity.StudyGroup;
+import com.api.meetudy.study.group.entity.StudyGroupMember;
+import com.api.meetudy.study.group.mapper.StudyGroupMapper;
+import com.api.meetudy.study.group.repository.StudyGroupMemberRepository;
+import com.api.meetudy.study.group.repository.StudyGroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GroupRetrievalService {
+
+    private final StudyGroupRepository groupRepository;
+    private final StudyGroupMemberRepository groupMemberRepository;
+    private final StudyGroupMapper studyGroupMapper;
+
+    @Transactional(readOnly = true)
+    public List<StudyGroupDto> getCreatedStudyGroups(Member member) {
+        List<StudyGroup> createdStudyGroups = groupRepository.findByLeader(member);
+        return studyGroupMapper.toStudyGroupDtoList(createdStudyGroups);
+    }
+
+    @Transactional(readOnly = true)
+    public List<StudyGroupDto> getJoinedStudyGroups(Member member) {
+        List<StudyGroupMember> groupMembers = groupMemberRepository.findByMember(member);
+        return studyGroupMapper.toStudyGroupDtoListFromMembers(groupMembers);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
       maximum-pool-size: 4
     url: jdbc:mysql://localhost:3306/meetudy
     username: root
-    password: juj75077507!@
+    password: password
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
### To-Do List

- [x] Implement API to request joining a study group.
- [x] Implement API to create a new study group.
- [x] Implement API to approve a study group join request.
- [x] Implement token refresh functionality.
- [x] Implement API to reject a study group join request.
- [x] Implement API to retrieve join requests for a study group.
- [x] Implement API to retrieve study groups created by the user.
- [x] Implement API to retrieve study groups the user has joined.
- [x] Add EnumValidator for validating enum values in request DTOs.
- [x] Add brief descriptions for each API endpoint in the controller.

closed #6