### PR TITLE
[feature/#20] Add API to retrieve detailed information of a study group

### DIFF
--- a/src/main/java/com/api/meetudy/auth/controller/AuthController.java
+++ b/src/main/java/com/api/meetudy/auth/controller/AuthController.java
@@ -9,7 +9,6 @@ import com.api.meetudy.global.response.status.ErrorStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/com/api/meetudy/auth/dto/EmailDto.java
+++ b/src/main/java/com/api/meetudy/auth/dto/EmailDto.java
@@ -1,10 +1,12 @@
 package com.api.meetudy.auth.dto;
 
+import jakarta.validation.constraints.Email;
 import lombok.Getter;
 
 @Getter
 public class EmailDto {
 
+    @Email
     private String email;
 
 }

--- a/src/main/java/com/api/meetudy/auth/dto/VerificationDto.java
+++ b/src/main/java/com/api/meetudy/auth/dto/VerificationDto.java
@@ -1,5 +1,7 @@
 package com.api.meetudy.auth.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,8 +9,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class VerificationDto {
 
+    @Email
     private String email;
 
+    @NotBlank
     private String code;
 
 }

--- a/src/main/java/com/api/meetudy/auth/service/EmailService.java
+++ b/src/main/java/com/api/meetudy/auth/service/EmailService.java
@@ -10,14 +10,12 @@ import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 @Service
 @RequiredArgsConstructor
@@ -33,7 +31,10 @@ public class EmailService {
     private final Map<String, Long> verificationExpiry = new HashMap<>();
     private static final long EXPIRY_TIME = 5 * 60 * 1000;
 
-    public String sendPasswordResetEmail(String sendTo) throws Exception {
+    public String sendPasswordResetEmail(String username, String sendTo) throws Exception {
+        Member member = memberRepository.findByUsernameAndEmail(username, sendTo)
+                .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
+
         String password = generateRandomCode();
 
         MimeMessage mimeMessage = mailSender.createMimeMessage();

--- a/src/main/java/com/api/meetudy/global/config/SecurityConfig.java
+++ b/src/main/java/com/api/meetudy/global/config/SecurityConfig.java
@@ -92,7 +92,8 @@ public class SecurityConfig {
                         .requestMatchers("/error/**").permitAll()
                         .requestMatchers("/members/**").permitAll()
                         .requestMatchers("/oauth2/callback/kakao").permitAll()
-                        .requestMatchers("/search/**").permitAll()
+                        .requestMatchers("/search/sort").hasRole("USER")
+                        .requestMatchers("/search/filter", "/search").permitAll()
                         .requestMatchers("/study-groups/**").hasRole("USER")
                 );
 

--- a/src/main/java/com/api/meetudy/global/init/DataInitializer.java
+++ b/src/main/java/com/api/meetudy/global/init/DataInitializer.java
@@ -146,6 +146,28 @@ public class DataInitializer implements CommandLineRunner {
                 .location(Location.SEOUL)
                 .build();
 
+        StudyGroup studyGroup5 = StudyGroup.builder()
+                .name("사회과학 스터디")
+                .description("사회과학 스터디입니다.")
+                .duration("2025-03-01 ~ 2025-05-01")
+                .maxParticipants(10)
+                .isOnline(true)
+                .method("온라인 ZOOM으로 진행합니다.")
+                .category(StudyCategory.SOCIAL_SCIENCES)
+                .location(Location.OTHERS)
+                .build();
+
+        StudyGroup studyGroup6 = StudyGroup.builder()
+                .name("피그마 스터디")
+                .description("피그마 스터디입니다.")
+                .duration("2025-03-01 ~ 2025-05-01")
+                .maxParticipants(10)
+                .isOnline(true)
+                .method("온라인 ZOOM으로 진행합니다.")
+                .category(StudyCategory.DESIGN)
+                .location(Location.OTHERS)
+                .build();
+
         StudyGroupMember groupMember1 = StudyGroupMember.builder()
                 .status(GroupMemberStatus.LEADER)
                 .member(member1)
@@ -197,7 +219,7 @@ public class DataInitializer implements CommandLineRunner {
         memberRepository.saveAll(Arrays.asList(member1, member2));
         interestRepository.saveAll(Arrays.asList(interest1, interest2, interest3, interest4));
         memberInterestRepository.saveAll(Arrays.asList(memberInterest1, memberInterest2, memberInterest3, memberInterest4, memberInterest5));
-        groupRepository.saveAll(Arrays.asList(studyGroup1, studyGroup2, studyGroup3, studyGroup4));
+        groupRepository.saveAll(Arrays.asList(studyGroup1, studyGroup2, studyGroup3, studyGroup4, studyGroup5, studyGroup6));
         groupMemberRepository.saveAll(Arrays.asList(groupMember1, groupMember2, groupMember3, groupMember4, groupMember5, groupMember6, groupMember7, groupMember8));
     }
 

--- a/src/main/java/com/api/meetudy/member/controller/MemberController.java
+++ b/src/main/java/com/api/meetudy/member/controller/MemberController.java
@@ -83,7 +83,7 @@ public class MemberController {
 
     @Operation(summary = "아이디 찾기 API")
     @PostMapping("/username")
-    public ResponseEntity<ApiResponse<String>> findUsername(@RequestBody EmailDto emailDto) {
+    public ResponseEntity<ApiResponse<String>> findUsername(@Valid @RequestBody EmailDto emailDto) {
         Member member = memberRepository.findByEmail(emailDto.getEmail())
                 .orElseThrow(() -> new CustomException(ErrorStatus.GROUP_NOT_FOUND));
         return ResponseEntity.ok(ApiResponse.onSuccess(member.getUsername()));
@@ -91,9 +91,9 @@ public class MemberController {
 
     @Operation(summary = "비밀번호 찾기 API")
     @PostMapping("/password")
-    public ResponseEntity<ApiResponse<String>> findPassword(@RequestBody EmailDto emailDto) {
+    public ResponseEntity<ApiResponse<String>> findPassword(@Valid @RequestBody PasswordFindingDto findingDto) {
         try {
-            String response = emailService.sendPasswordResetEmail(emailDto.getEmail());
+            String response = emailService.sendPasswordResetEmail(findingDto.getUsername(), findingDto.getEmail());
             return ResponseEntity.ok(ApiResponse.onSuccess(response));
         } catch (Exception e) {
             throw new CustomException(ErrorStatus.SEND_EMAIL_FAILED);
@@ -102,16 +102,16 @@ public class MemberController {
 
     @Operation(summary = "아이디 중복 확인 API")
     @PostMapping("/username/duplication")
-    public ResponseEntity<ApiResponse<Boolean>> checkUsernameDuplication(@RequestBody UsernameDuplicationDto duplicationDto) {
+    public ResponseEntity<ApiResponse<Boolean>> checkUsernameDuplication(@Valid @RequestBody UsernameDuplicationDto duplicationDto) {
         boolean isUsernameExist = memberRepository.existsByUsername(duplicationDto.getUsername());
-        return ResponseEntity.ok(ApiResponse.onSuccess(isUsernameExist));
+        return ResponseEntity.ok(ApiResponse.onSuccess(!isUsernameExist));
     }
 
     @Operation(summary = "닉네임 중복 확인 API")
     @GetMapping("/nickname/duplication")
     public ResponseEntity<ApiResponse<Boolean>> checkNicknameDuplication(@RequestParam String nickname) {
         boolean isNicknameExist = memberRepository.existsByNickname(nickname);
-        return ResponseEntity.ok(ApiResponse.onSuccess(isNicknameExist));
+        return ResponseEntity.ok(ApiResponse.onSuccess(!isNicknameExist));
     }
 
 }

--- a/src/main/java/com/api/meetudy/member/dto/PasswordFindingDto.java
+++ b/src/main/java/com/api/meetudy/member/dto/PasswordFindingDto.java
@@ -1,0 +1,16 @@
+package com.api.meetudy.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class PasswordFindingDto {
+
+    @NotBlank
+    private String username;
+
+    @Email
+    private String email;
+
+}

--- a/src/main/java/com/api/meetudy/member/dto/UsernameDuplicationDto.java
+++ b/src/main/java/com/api/meetudy/member/dto/UsernameDuplicationDto.java
@@ -1,10 +1,12 @@
 package com.api.meetudy.member.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class UsernameDuplicationDto {
 
+    @NotBlank
     private String username;
 
 }

--- a/src/main/java/com/api/meetudy/member/repository/MemberRepository.java
+++ b/src/main/java/com/api/meetudy/member/repository/MemberRepository.java
@@ -17,4 +17,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByNickname(String nickname);
 
+    Optional<Member> findByUsernameAndEmail(String username, String email);
+
 }

--- a/src/main/java/com/api/meetudy/study/group/controller/StudyGroupController.java
+++ b/src/main/java/com/api/meetudy/study/group/controller/StudyGroupController.java
@@ -25,7 +25,7 @@ public class StudyGroupController {
     private final GroupManagementService groupManagementService;
 
     @Operation(summary = "스터디 그룹 가입 요청 API")
-    @PostMapping("/{groupId}")
+    @PostMapping("/{groupId}/join-requests")
     public ResponseEntity<ApiResponse<String>> requestJoinGroup(@PathVariable Long groupId,
                                                                 Principal principal) {
         String message = studyGroupService.requestJoinGroup(groupId, authenticationService.getCurrentMember(principal));
@@ -65,7 +65,7 @@ public class StudyGroupController {
     }
 
     @Operation(summary = "스터디 그룹에 대한 가입 요청 조회 API")
-    @GetMapping("/{groupId}")
+    @GetMapping("/{groupId}/join-requests")
     public ResponseEntity<ApiResponse<List<StudyGroupApplicantDto>>> getJoinRequests(@PathVariable Long groupId,
                                                                                      Principal principal) {
         List<StudyGroupApplicantDto> response = groupManagementService.getJoinRequests(groupId, authenticationService.getCurrentMember(principal));
@@ -90,6 +90,13 @@ public class StudyGroupController {
     @GetMapping("/pending-groups")
     public ResponseEntity<ApiResponse<List<StudyGroupDto>>> getPendingStudyGroups(Principal principal) {
         List<StudyGroupDto> response = studyGroupService.getPendingStudyGroups(authenticationService.getCurrentMember(principal));
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "특정 스터디 그룹 조회 API")
+    @GetMapping("/{groupId}")
+    public ResponseEntity<ApiResponse<StudyGroupDto>> getStudyGroupById(@PathVariable Long groupId) {
+        StudyGroupDto response = studyGroupService.getStudyGroupById(groupId);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 

--- a/src/main/java/com/api/meetudy/study/group/dto/StudyGroupDto.java
+++ b/src/main/java/com/api/meetudy/study/group/dto/StudyGroupDto.java
@@ -10,6 +10,8 @@ import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 public class StudyGroupDto {
@@ -55,5 +57,8 @@ public class StudyGroupDto {
     @Schema(description = "The recommendation score of the study group, based on matching the user's interests and preferences.",
             example = "4.5")
     private double score;
+
+    @Schema(description = "The creation timestamp of the study group.")
+    private LocalDateTime createdAt;
 
 }

--- a/src/main/java/com/api/meetudy/study/group/service/StudyGroupService.java
+++ b/src/main/java/com/api/meetudy/study/group/service/StudyGroupService.java
@@ -58,4 +58,12 @@ public class StudyGroupService {
         return studyGroupMapper.toStudyGroupDtoListFromMembers(pendingGroupMembers);
     }
 
+    @Transactional(readOnly = true)
+    public StudyGroupDto getStudyGroupById(Long groupId) {
+        StudyGroup studyGroup = groupRepository.findById(groupId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.GROUP_NOT_FOUND));
+
+        return studyGroupMapper.toStudyGroupDto(studyGroup);
+    }
+
 }

--- a/src/main/java/com/api/meetudy/study/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/api/meetudy/study/recommendation/service/RecommendationService.java
@@ -42,8 +42,8 @@ public class RecommendationService {
         }
 
         return recommendedGroups.stream()
-                .sorted(Comparator.comparingDouble(StudyGroupDto::getScore).reversed())
-                .limit(10)
+                .sorted(Comparator.comparingDouble(StudyGroupDto::getScore).reversed()
+                        .thenComparing(StudyGroupDto::getCreatedAt, Comparator.reverseOrder()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/api/meetudy/study/search/controller/SearchController.java
+++ b/src/main/java/com/api/meetudy/study/search/controller/SearchController.java
@@ -1,5 +1,6 @@
 package com.api.meetudy.study.search.controller;
 
+import com.api.meetudy.auth.service.AuthenticationService;
 import com.api.meetudy.global.response.ApiResponse;
 import com.api.meetudy.study.group.dto.StudyGroupDto;
 import com.api.meetudy.study.group.enums.Location;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.security.Principal;
 import java.util.List;
 
 @RestController
@@ -21,6 +23,7 @@ import java.util.List;
 public class SearchController {
 
     private final SearchService searchService;
+    private final AuthenticationService authenticationService;
 
     @Operation(summary = "스터디 그룹 검색 API")
     @GetMapping
@@ -41,9 +44,9 @@ public class SearchController {
 
     @Operation(summary = "스터디 그룹 정렬 API")
     @GetMapping("/sort")
-    public ResponseEntity<ApiResponse<List<StudyGroupDto>>> sortStudyGroups(@RequestParam List<Long> groupIds,
-                                                                            @RequestParam(defaultValue = "LATEST") String sortBy) {
-        List<StudyGroupDto> response = searchService.sortStudyGroups(groupIds, sortBy);
+    public ResponseEntity<ApiResponse<List<StudyGroupDto>>> sortStudyGroups(@RequestParam(defaultValue = "LATEST") String sortBy,
+                                                                            Principal principal) {
+        List<StudyGroupDto> response = searchService.sortStudyGroups(sortBy, authenticationService.getCurrentMember(principal));
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 


### PR DESCRIPTION
### To-Do List

- [x] Add validation annotations to DTO classes.
- [x] Add username parameter to sendPasswordResetEmail function.
- [x] Update security configuration for search-related endpoints.
- [x] Add additional dummy data for study groups.
- [x] Add createdAt field to study group DTO.
- [x] Implement API to retrieve detailed information of a specific study group.
- [x] Remove limit on the number of recommended study groups.
- [x] Modify study group sorting API to sort all groups instead of filtering by specific IDs.

closed #20