### PR TITLE
[feature/#56] Add caching and eviction logic for posts and comments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ dependencies {
 
 	// websocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/api/meetudy/MeetudyApplication.java
+++ b/src/main/java/com/api/meetudy/MeetudyApplication.java
@@ -2,9 +2,11 @@ package com.api.meetudy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@EnableCaching
 @SpringBootApplication
 public class MeetudyApplication {
 

--- a/src/main/java/com/api/meetudy/comment/service/CommentService.java
+++ b/src/main/java/com/api/meetudy/comment/service/CommentService.java
@@ -11,6 +11,9 @@ import com.api.meetudy.global.response.exception.CustomException;
 import com.api.meetudy.global.response.status.ErrorStatus;
 import com.api.meetudy.member.entity.Member;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,8 +25,10 @@ public class CommentService {
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final CommentMapper commentMapper;
+    private final CacheManager cacheManager;
 
     @Transactional
+    @CacheEvict(value = "postDetails", key = "#postId")
     public String addComment(Long postId, CommentRequestDto commentRequestDto, Member member) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.POST_NOT_FOUND));
@@ -43,15 +48,29 @@ public class CommentService {
     public String updateComment(Long commentId, CommentRequestDto commentRequestDto, Member member) {
         Comment comment = findCommentWithAuthorCheck(commentId, member.getId());
         comment.updateComment(commentRequestDto.getContent());
-
         commentRepository.save(comment);
+
+        Long postId = comment.getPost().getId();
+
+        Cache cache = cacheManager.getCache("postDetails");
+        if (cache != null && postId != null) {
+            cache.evict(postId);
+        }
+
         return "Comment has been successfully updated.";
     }
 
     @Transactional
     public String deleteComment(Long commentId, Member member) {
         Comment comment = findCommentWithAuthorCheck(commentId, member.getId());
+        Long postId = comment.getPost().getId();
+
         commentRepository.delete(comment);
+
+        Cache cache = cacheManager.getCache("postDetails");
+        if (cache != null && postId != null) {
+            cache.evict(postId);
+        }
 
         return "Comment has been successfully deleted.";
     }

--- a/src/main/java/com/api/meetudy/global/config/RedisRepositoryConfig.java
+++ b/src/main/java/com/api/meetudy/global/config/RedisRepositoryConfig.java
@@ -1,14 +1,24 @@
 package com.api.meetudy.global.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 @Configuration
 @EnableRedisRepositories
@@ -25,20 +35,47 @@ public class RedisRepositoryConfig {
         return new LettuceConnectionFactory(host, port);
     }
 
+    private ObjectMapper redisObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+        return mapper;
+    }
+
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
 
-        Jackson2JsonRedisSerializer<Object> serializer = new Jackson2JsonRedisSerializer<>(Object.class);
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper());
+
         redisTemplate.setValueSerializer(serializer);
         redisTemplate.setHashValueSerializer(serializer);
 
         redisTemplate.afterPropertiesSet();
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper());
+
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(1))
+                .disableCachingNullValues()
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(cacheConfig)
+                .build();
     }
 
 }

--- a/src/main/java/com/api/meetudy/post/controller/PostController.java
+++ b/src/main/java/com/api/meetudy/post/controller/PostController.java
@@ -32,10 +32,10 @@ public class PostController {
 
     @Operation(summary = "게시글 수정 API")
     @PatchMapping("/{postId}")
-    public ResponseEntity<ApiResponse<String>> updatePost(@PathVariable Long postId,
+    public ResponseEntity<ApiResponse<PostDetailDto>> updatePost(@PathVariable Long postId,
                                                           @Valid @RequestBody PostRequestDto postRequestDto,
                                                           Principal principal) {
-        String response = postService.updatePost(postId, postRequestDto, authenticationService.getCurrentMember(principal));
+        PostDetailDto response = postService.updatePost(postId, postRequestDto, authenticationService.getCurrentMember(principal));
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 

--- a/src/main/java/com/api/meetudy/post/dto/PostDetailDto.java
+++ b/src/main/java/com/api/meetudy/post/dto/PostDetailDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -42,6 +43,6 @@ public class PostDetailDto {
     private Boolean isMyPost;
 
     @Schema(description = "List of comments associated with the post.")
-    private List<CommentDto> comments;
+    private List<CommentDto> comments = new ArrayList<>();
 
 }

--- a/src/main/java/com/api/meetudy/post/service/PostService.java
+++ b/src/main/java/com/api/meetudy/post/service/PostService.java
@@ -10,6 +10,10 @@ import com.api.meetudy.global.response.exception.CustomException;
 import com.api.meetudy.global.response.status.ErrorStatus;
 import com.api.meetudy.member.entity.Member;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +27,7 @@ public class PostService {
     private final PostMapper postMapper;
 
     @Transactional
+    @CacheEvict(value = {"posts", "postDetails"}, allEntries = true)
     public String createPost(PostRequestDto postRequestDto, Member member) {
         Post post = postMapper.toPost(postRequestDto, member);
         postRepository.save(post);
@@ -31,15 +36,21 @@ public class PostService {
     }
 
     @Transactional
-    public String updatePost(Long postId, PostRequestDto postRequestDto, Member member) {
+    @CachePut(value = "postDetails", key = "#postId")
+    @CacheEvict(value = "posts", allEntries = true)
+    public PostDetailDto updatePost(Long postId, PostRequestDto postRequestDto, Member member) {
         Post post = findPostWithAuthorCheck(postId, member.getId());
         post.updatePost(postRequestDto.getTitle(), postRequestDto.getContent(), postRequestDto.getPostCategory());
-
         postRepository.save(post);
-        return "Post has been successfully updated.";
+
+        return postMapper.toPostDetailDtoWithSortedComments(post, member.getId());
     }
 
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = "postDetails", key = "#postId"),
+            @CacheEvict(value = "posts", allEntries = true)
+    })
     public String deletePost(Long postId, Member member) {
         Post post = findPostWithAuthorCheck(postId, member.getId());
         postRepository.delete(post);
@@ -48,12 +59,14 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "posts")
     public List<PostDto> getAllPosts() {
         List<Post> posts = postRepository.findAllByOrderByCreatedAtAsc();
         return postMapper.toPostDtoList(posts);
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "postDetails", key = "#postId")
     public PostDetailDto getPostById(Long postId, Member member) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.POST_NOT_FOUND));
@@ -61,6 +74,7 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "postsByMember", key = "#member.id")
     public List<PostDto> getPostsByMember(Member member) {
         List<Post> posts = postRepository.findByAuthorOrderByCreatedAtAsc(member);
         return postMapper.toPostDtoList(posts);


### PR DESCRIPTION
### To-Do List

- [x] Add Jackson JSR310 module to build.gradle for Java 8 date/time support.
- [x] Enable caching by adding @EnableCaching in MeetudyApplication.
- [x] Add query in ChatController to fetch a chat room along with its members by ID.
- [x] Configure RedisCacheManager and customize ObjectMapper for LocalDateTime in RedisRepositoryConfig.
- [x] Initialize the comments list by default in PostDetailDto.
- [x] Change the return type of the updatePost API from String to PostDetailDto.
- [x] Add Redis caching support for Post and Comment entities.

closed #56